### PR TITLE
修复 HTTP/2 GOAWAY 场景下请求体无法重试

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.23
 
     - name: Test
       run: go test ./...

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -204,6 +205,33 @@ func TestRequest_Send(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		resp := Post("http://%s/500", nextAddr()).Send(nil)
 		assert.Error(t, resp.Err())
+	})
+
+	t.Run("json body is replayable", func(t *testing.T) {
+		checked := false
+		before := func(ctx context.Context, request *http.Request) (context.Context, error) {
+			if !assert.NotNil(t, request.GetBody) {
+				return ctx, nil
+			}
+			body, err := request.GetBody()
+			if !assert.NoError(t, err) {
+				return ctx, nil
+			}
+			defer body.Close()
+			data, err := io.ReadAll(body)
+			assert.NoError(t, err)
+			assert.JSONEq(t, `{"name":"hasaki"}`, string(data))
+			checked = true
+			return ctx, nil
+		}
+
+		resp := Post("http://%s", addr).
+			SetBefore(before).
+			Send(struct {
+				Name string `json:"name"`
+			}{Name: "hasaki"})
+		assert.NoError(t, resp.Err())
+		assert.True(t, checked)
 	})
 }
 

--- a/request.go
+++ b/request.go
@@ -182,6 +182,16 @@ func (c *Request) Send(body any) *Response {
 		resp.err = errors.WithStack(err)
 		return resp
 	}
+	// 自定义编码器返回的 Reader 不一定是 net/http 能识别的可重放类型。
+	// 为内存请求体补充 GetBody，使 HTTP/2 Transport 收到 GOAWAY 时可以安全重试。
+	if req.GetBody == nil {
+		if data, ok := reader.(BytesReadCloser); ok {
+			data := bytes.Clone(data.Bytes())
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(data)), nil
+			}
+		}
+	}
 
 	if c.method == http.MethodGet && body == nil {
 		c.headers.Del("Content-Type")


### PR DESCRIPTION
为内存请求体提供 GetBody，使 Transport 能安全重放 POST 请求。